### PR TITLE
Jules' Work

### DIFF
--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -3,13 +3,38 @@ import ElevatedBox from "../components/ElevatedBox.astro"
 import InnerLayout from "../layouts/InnerLayout.astro"
 ---
 
-<InnerLayout title="wip">
-  <div class="flex w-full min-h-screen flex-col items-center justify-center gap-8 py-12">
-    <h1>kutelabs. a kute way to learn kotlin :)</h1>
-    <a href="/learn" data-astro-prefetch>
-      <ElevatedBox elevation={2} hoverable class="bg-beige-50">
-        <p class="p-4">Go to available lessons</p>
+<InnerLayout title="kutelabs - Learn to Code the Fun Way!">
+  <div class="flex w-full flex-col items-center justify-center gap-0 py-0">
+    <section class="flex flex-col items-center justify-center text-center px-4 py-16 min-h-[calc(100vh-6rem)]">
+      <h1 class="font-gummy text-6xl md:text-8xl text-outlined mb-8">Spark Your Inner Coder!</h1>
+      <a href="/learn">
+        <ElevatedBox elevation={2} hoverable={true} class="bg-purp-400 text-white">
+          <p class="p-4 text-2xl font-poppins">Start Learning Now!</p>
+        </ElevatedBox>
+      </a>
+    </section>
+    <section class="w-full bg-beige-100 py-16 px-4 text-center">
+      <h2 class="font-poppins text-4xl md:text-5xl text-black mb-12">See What You Can Build!</h2>
+      <div class="flex flex-wrap justify-center items-start gap-8 md:gap-12">
+        <ElevatedBox elevation={1} class="bg-beige-50 w-64 h-48 flex items-center justify-center">
+          <p class="text-beige-500 font-poppins text-lg">Block Image Placeholder 1</p>
+        </ElevatedBox>
+        <ElevatedBox elevation={1} class="bg-beige-50 w-64 h-48 flex items-center justify-center">
+          <p class="text-beige-500 font-poppins text-lg">Block Image Placeholder 2</p>
+        </ElevatedBox>
+        <ElevatedBox elevation={1} class="bg-beige-50 w-64 h-48 flex items-center justify-center">
+          <p class="text-beige-500 font-poppins text-lg">Block Image Placeholder 3</p>
+        </ElevatedBox>
+      </div>
+    </section>
+    <section class="w-full py-16 px-4 text-center">
+      <h2 class="font-gummy text-5xl md:text-7xl text-outlined mb-8">Ready to Play?</h2>
+      <p class="font-poppins text-xl text-black max-w-2xl mx-auto mb-12">
+        Jump into our colorful world of code! Solve puzzles, build amazing things, and unleash your creativity. Learning to code has never been this much fun. What will you create today?
+      </p>
+      <ElevatedBox elevation={1} class="bg-beige-50 inline-block">
+        <img src="/images/illustration_debug_launch.png" alt="Fun illustration of coding blocks launching" class="w-full max-w-sm md:max-w-md mx-auto" />
       </ElevatedBox>
-    </a>
+    </section>
   </div>
 </InnerLayout>


### PR DESCRIPTION
Adds a new landing page at `/` (`app/src/pages/index.astro`).

The new page includes:
- A hero section with a prominent call-to-action (CTA) linking to `/learn`.
- A "Block Showcase" section with three placeholders for images of editor blocks.
- An "Engaging Content" section with descriptive text and an illustration to ensure the page is longer than one screen height.
- Styling that matches the existing web app's neobrutalist aesthetic, utilizing Tailwind CSS, custom fonts ("Sour Gummy", "Poppins"), and the "ElevatedBox" component.
- The page title has been updated to "kutelabs - Learn to Code the Fun Way!".

The page structure was validated, and `astro check` passes for this file. A separate project-level build issue was noted during testing but is believed to be unrelated to these specific changes.